### PR TITLE
Explicitly cast void pointer to fix the compilation in clang++.

### DIFF
--- a/include/tiny_ktx/tinyktx.h
+++ b/include/tiny_ktx/tinyktx.h
@@ -1044,7 +1044,7 @@ void const *TinyKtx_ImageRawData(TinyKtx_ContextHandle handle, uint32_t mipmaple
 	if (size == 0)
 		return NULL;
 
-	ctx->mipmaps[mipmaplevel] = ctx->callbacks.alloc(ctx->user, size);
+	ctx->mipmaps[mipmaplevel] = (uint8_t const*) ctx->callbacks.alloc(ctx->user, size);
 	if (ctx->mipmaps[mipmaplevel]) {
 		ctx->callbacks.read(ctx->user, (void *) ctx->mipmaps[mipmaplevel], size);
 	}


### PR DESCRIPTION
Explicit pointer casting is required when compiling tiny_ktx in C++ compiler(at least confirmed with clang++)

```
../include/tiny_ktx/tinyktx.h:1047:30: error: assigning to 'const uint8_t *'
      (aka 'const unsigned char *') from incompatible type 'void *'
```